### PR TITLE
Convert remaining 'drupal' references to 'backdrop'.

### DIFF
--- a/codemirror_widget.js
+++ b/codemirror_widget.js
@@ -2,7 +2,7 @@
 
   var codeMirrorEditors = [];
 
-  Drupal.behaviors.codemirrorWidget = {
+  Backdrop.behaviors.codemirrorWidget = {
     attach: function (context, settings) {
       $('textarea.codemirror', context).each(function (i, v) {
         //console.log($(this));
@@ -10,7 +10,7 @@
         $(this).once('codemirror', function () {
           codeMirrorEditors.push(CodeMirror.fromTextArea($(this).get(0), {
             lineNumbers: true,
-            theme: Drupal.settings.codemirror[i].theme,
+            theme: Backdrop.settings.codemirror[i].theme,
           }));
         });
       });
@@ -39,7 +39,7 @@
         var id = $(this).attr('id');
         var editor = CodeMirror.fromTextArea($(this).get(0), {
           lineNumbers: true,
-          theme: Drupal.settings.codemirror[id].theme,
+          theme: Backdrop.settings.codemirror[id].theme,
         });
       });
       */
@@ -65,7 +65,7 @@
 
       }
       */
-    },
+    }
   };
 
 })(jQuery);

--- a/codemirror_widget.module
+++ b/codemirror_widget.module
@@ -104,7 +104,7 @@ function codemirror_widget_field_widget_form(&$form, &$form_state, $field, $inst
     '#attached' => array(
       'js' => array(
         array(
-          'data' => drupal_get_path('module', 'codemirror_widget') . '/codemirror_widget.js',
+          'data' => backdrop_get_path('module', 'codemirror_widget') . '/codemirror_widget.js',
           'type' => 'file',
         ),
         array(


### PR DESCRIPTION
Hi @sirkitree! I noticed there were a few references to Drupal in the code. Swapping these out for Backdrop will allow the module to run with compatibility mode (in settings.php) turned off.
